### PR TITLE
RHMAP-12349 fix Push notifications doesn't work with alias

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,5 +5,5 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'PushStarter' do
-	pod 'FeedHenry', '~> 4.1.1'
+	pod 'FeedHenry', :git => 'https://github.com/feedhenry/fh-ios-swift-sdk.git', :branch => '4.1.2'
 end


### PR DESCRIPTION
Use the new 4.1.2 branch of the SDK with the fix